### PR TITLE
Use pathlib instead of os to simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ In the activated virtual environment, run the `main.py` script
 ```bash
 python main.py
 ```
+
+> **NOTE:** The downloaded Facebook data must be in the same directory as the `main.py` script at the path `messages/inbox`.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import json
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,35 +20,28 @@ def analyze_messages():
 
 	# Define root path
 	# TODO: User needs to replace root with their own file path
-	root = r'C:\Users\Jerry\Documents\Programming\Python\Personal Projects\FB Messenger Analyzer\facebook-jerrysun123\messages\inbox'
-	dir_list = os.listdir(root)
+	root = Path.cwd() / "messages" / "inbox"
 
 	# Access the first level of subfolder from "inbox"
 	# (e.g. "folder" == DylanSteele in the example above)
-	for folder in dir_list:
+	for folder in root.iterdir():
 		count_values = 0
-		temp = root + "\\" + folder
-		convo_dir = os.listdir(temp)
-
 		# Access the individuals .json files in each conversations "folder"
-		# (e.g. "json_file" == file1.json in the example above)
-		# and sum volume of all messages sent
-		for json_file in convo_dir:
-			if json_file.endswith(".json"):
-				convo = open(temp+"\\"+json_file,"r")
-				data = json.load(convo)
-				if 'messages' in data:
-					count_values += len(data['messages'])
-					convo.close()
-
-		# Populates the fb_conversations dictionary with an active Facebook
-		# conversation. If a key representing conversations with users already
-		# exists, sum all values together for that key
-		if (data['title']) != 'Facebook User':
-			if (data['title']) not in fb_conversations:
-				fb_conversations[data['title']] = count_values
-			else:
-				fb_conversations[data['title']] = fb_conversations.get(data['title']) + count_values
+		for message_file in folder.glob("*.json"):
+			with message_file.open() as f:
+				data = json.load(f)
+			
+			if 'messages' in data:
+				count_values += len(data['messages'])
+			
+			# Populates the fb_conversations dictionary with an active Facebook
+			# conversation. If a key representing conversations with users already
+			# exists, sum all values together for that key
+			if (data['title']) != 'Facebook User':
+				if (data['title']) not in fb_conversations:
+					fb_conversations[data['title']] = count_values
+				else:
+					fb_conversations[data['title']] = fb_conversations.get(data['title']) + count_values
 
 	# extract the top 10 most messaged keys and place them in a new dictionary
 	ten_largest = nlargest(10, fb_conversations, key = fb_conversations.get)


### PR DESCRIPTION
`pathlib` is a Python 3 addition that greatly improves the API for interacting with paths/files/directories.

Turn off the whitespace changes to highlight the actual code that's changing.